### PR TITLE
Omniscia audit feedback

### DIFF
--- a/contracts/CowswapOrderSigner.sol
+++ b/contracts/CowswapOrderSigner.sol
@@ -13,8 +13,8 @@ contract CowswapOrderSigner {
     using GPv2Order for GPv2Order.Data;
 
     GPv2Signing public immutable signing;
-    bytes32 immutable domainSeparator;
-    address immutable deployedAt;
+    bytes32 public immutable domainSeparator;
+    address public immutable deployedAt;
 
     constructor(GPv2Signing _signing) {
         signing = _signing;

--- a/contracts/CowswapOrderSigner.sol
+++ b/contracts/CowswapOrderSigner.sol
@@ -24,7 +24,7 @@ contract CowswapOrderSigner {
         deployedAt = address(this);
     }
 
-    function _setPresignature(
+    function _setPreSignature(
         GPv2Order.Data calldata order,
         bool signed
     ) internal {
@@ -52,10 +52,10 @@ contract CowswapOrderSigner {
             "Fee too high"
         );
 
-        _setPresignature(order, true);
+        _setPreSignature(order, true);
     }
 
     function unsignOrder(GPv2Order.Data calldata order) external {
-        _setPresignature(order, false);
+        _setPreSignature(order, false);
     }
 }

--- a/contracts/CowswapOrderSigner.sol
+++ b/contracts/CowswapOrderSigner.sol
@@ -11,6 +11,7 @@ import "./cowProtocol/interfaces/IERC20.sol";
 
 contract CowswapOrderSigner {
     using GPv2Order for GPv2Order.Data;
+    using GPv2Order for bytes;
 
     GPv2Signing public immutable signing;
     bytes32 public immutable domainSeparator;
@@ -32,12 +33,7 @@ contract CowswapOrderSigner {
         // compute order UID
         bytes32 orderDigest = order.hash(domainSeparator);
         bytes memory orderUid = new bytes(GPv2Order.UID_LENGTH);
-        GPv2Order.packOrderUidParams(
-            orderUid,
-            orderDigest,
-            address(this),
-            order.validTo
-        );
+        orderUid.packOrderUidParams(orderDigest, address(this), order.validTo);
 
         signing.setPreSignature(orderUid, signed);
     }

--- a/contracts/CowswapOrderSigner.sol
+++ b/contracts/CowswapOrderSigner.sol
@@ -48,7 +48,7 @@ contract CowswapOrderSigner {
             "Dishonest valid duration"
         );
         require(
-            order.feeAmount <= (order.sellAmount * feeAmountBP) / 10_000 + 1,
+            order.feeAmount <= (order.sellAmount * feeAmountBP) / 100_00 + 1,
             "Fee too high"
         );
 

--- a/contracts/CowswapOrderSigner.sol
+++ b/contracts/CowswapOrderSigner.sol
@@ -34,7 +34,7 @@ contract CowswapOrderSigner {
             "Dishonest valid duration"
         );
         require(
-            order.feeAmount <= (order.sellAmount * feeAmountBP) / 10000 + 1,
+            order.feeAmount <= (order.sellAmount * feeAmountBP) / 10_000 + 1,
             "Fee too high"
         );
 

--- a/contracts/CowswapOrderSigner.sol
+++ b/contracts/CowswapOrderSigner.sol
@@ -17,6 +17,7 @@ contract CowswapOrderSigner {
     address public immutable deployedAt;
 
     constructor(GPv2Signing _signing) {
+        require(address(_signing) != address(0), "Invalid signing address");
         signing = _signing;
         domainSeparator = _signing.domainSeparator();
         deployedAt = address(this);

--- a/test/CowswapOrderSigner.ts
+++ b/test/CowswapOrderSigner.ts
@@ -17,7 +17,7 @@ import {
   GPv2Signing,
   GPv2Signing__factory,
 } from "../typechain-types";
-import { keccak256, solidityKeccak256 } from "ethers/lib/utils";
+import { solidityKeccak256 } from "ethers/lib/utils";
 import { JsonRpcProvider } from "@ethersproject/providers";
 import { BigNumber, Contract } from "ethers";
 

--- a/test/CowswapOrderSigner.ts
+++ b/test/CowswapOrderSigner.ts
@@ -64,7 +64,7 @@ describe("CowswapOrderSigner contract", () => {
       buyAmount: "474505929366652675891",
       validTo: now + 60 * 30,
       appData: solidityKeccak256(["string"], [appData]),
-      feeAmount: "5174075756534068",
+      feeAmount: "19174075756534068",
       kind: ethers.utils.id("sell"),
       partiallyFillable: false,
       sellTokenBalance: ethers.utils.id("erc20"),
@@ -111,17 +111,22 @@ describe("CowswapOrderSigner contract", () => {
 
       const cowApi = new OrderBookApi({ chainId: 1 });
 
-      const expectedUid = await cowApi.sendOrder({
-        ...demoOrder,
-        kind: OrderKind.SELL,
-        sellTokenBalance: SellTokenSource.ERC20,
-        buyTokenBalance: BuyTokenDestination.ERC20,
-        from: avatar.address,
-        appData: appData,
-        appDataHash: demoOrder.appData,
-        signingScheme: SigningScheme.PRESIGN,
-        signature: "0x", // must be empty for presign
-      });
+      const expectedUid = await cowApi
+        .sendOrder({
+          ...demoOrder,
+          kind: OrderKind.SELL,
+          sellTokenBalance: SellTokenSource.ERC20,
+          buyTokenBalance: BuyTokenDestination.ERC20,
+          from: avatar.address,
+          appData: appData,
+          appDataHash: demoOrder.appData,
+          signingScheme: SigningScheme.PRESIGN,
+          signature: "0x", // must be empty for presign
+        })
+        .catch((e) => {
+          console.error(e);
+          throw e;
+        });
 
       // order UID is not yet signed
       expect(await cowswap.preSignature(expectedUid)).to.equal(0);
@@ -210,17 +215,22 @@ describe("CowswapOrderSigner contract", () => {
       // It's not possible to send multiple orders with the same UID, so we need to modify the order
       const demoOrder2 = { ...demoOrder, validTo: demoOrder.validTo + 1 };
 
-      const expectedUid = await cowApi.sendOrder({
-        ...demoOrder2,
-        kind: OrderKind.SELL,
-        sellTokenBalance: SellTokenSource.ERC20,
-        buyTokenBalance: BuyTokenDestination.ERC20,
-        from: avatar.address,
-        appData: appData,
-        appDataHash: demoOrder2.appData,
-        signingScheme: SigningScheme.PRESIGN,
-        signature: "0x", // must be empty for presign
-      });
+      const expectedUid = await cowApi
+        .sendOrder({
+          ...demoOrder2,
+          kind: OrderKind.SELL,
+          sellTokenBalance: SellTokenSource.ERC20,
+          buyTokenBalance: BuyTokenDestination.ERC20,
+          from: avatar.address,
+          appData: appData,
+          appDataHash: demoOrder2.appData,
+          signingScheme: SigningScheme.PRESIGN,
+          signature: "0x", // must be empty for presign
+        })
+        .catch((e) => {
+          console.error(e);
+          throw e;
+        });
 
       // sign the order
       const { data: signData } =


### PR DESCRIPTION
### This PR addresses all points raised in the audit by Omniscia.

Some of the audit findings concern third-party contracts from CoW Protocol. We copied the contract sources of all files in the contracts/cowProtocol directory from https://github.com/cowprotocol/contracts/releases/tag/v1.3.2. The only modification applied was to the solidity pragma (changing it from `pragma solidity ^0.7.6; pragma abicoder v2;` to `pragma solidity ^0.8.12`). We won't apply any changes to these contracts since they lie outside of our control as they are maintained by the CoW Protocol team and for our purposes only define the environment of the CowswapOrderSigner contract. In particular, we will not address the following audit feedback points:

- **GPS-01M**: out-of-scope since the identified issue lies within the CoW protocol's contracts, which Gnosis Guild has no control over
- **COS-02C**: CoW Protocol sources do not contain interface definitions but only the abstract contract. Rather than minimizing the code footprint we want to minimize manual modifications to the copied original sources.
- **GPO-01C**, **GPS-01C**: code style issues in third-party code

### In response to the additional point from the audit overview:
> As an additional point, we urge the Gnosis Guild team to clarify why the validTo and feeAmount sanitizations have been set in place given that they are already present as "immutable" arguments of the [CowswapOrderSigner::signOrder](https://github.com/gnosis/cow-order-signer/blob/83d1ffe1abdf186e824400a3caa0b7733065742f/contracts/CowswapOrderSigner.sol#L25-L51) function call.

The purpose of the CowswapOrderSigner is exposing all parameters of the order to sign, so they can be scoped via [Zodiac Roles](https://github.com/gnosis/zodiac-modifier-roles/tree/v2.1). Zodiac Roles allows scoping parameters only to static values. Due to their dynamic nature it is impractical to enforce values on an order's `feeAmount` and `validTo` timestamp.

For this reason, `CowswapOrderSigner.signOrder` takes two parameters in addition to the CoW Protocol order fields:
- `uint32 validDuration`
- `uint256 feeAmountBP`

The sanitizations of these parameters force the caller to honestly express the order's absolute `feeAmount` and `validTo` timestamp in relative terms. This allows defining Roles conditions on these relative values, i.e., enforcing a maximum allowed validity duration for orders and setting a maximum allowed fee as a percentage of the sell amount.